### PR TITLE
Updated `BSScheduler` base class to accept schedulers not depending on DataLoader

### DIFF
--- a/tests/test_ConstantBS.py
+++ b/tests/test_ConstantBS.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import ConstantBS
+from bs_scheduler import ConstantBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, rint
+    get_batch_sizes_across_epochs, BSTest, rint, batched_dataset
 
 
 class TestConstantBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'factor': 5.0,
+            'milestone': 5
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, ConstantBS, batch_size_manager, **kwargs)
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)

--- a/tests/test_CosineAnnealingBS.py
+++ b/tests/test_CosineAnnealingBS.py
@@ -37,7 +37,7 @@ class TestCosineAnnealingBS(BSTest):
     def test_dataloader_batch_size(self):
         base_batch_size = 10
         total_iters = 50
-        n_epochs = 500
+        n_epochs = 200
         max_batch_size = 100
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         scheduler = CosineAnnealingBS(dataloader, total_iters=total_iters, max_batch_size=max_batch_size)
@@ -47,7 +47,7 @@ class TestCosineAnnealingBS(BSTest):
                                 47, 49, 52, 55, 58, 61, 63, 66, 69, 72, 74, 77, 79, 81, 84, 86, 88, 90, 91, 93, 94, 96,
                                 97, 98, 99, 99, 100, 100, 100, 100, 100, 99, 99, 98, 97, 96, 94, 93, 91, 90, 88, 86, 84,
                                 81, 79, 77, 74, 72, 69, 66, 63, 61, 58, 55, 52, 49, 47, 44, 41, 38, 36, 33, 31, 29, 26,
-                                24, 22, 20, 19, 17, 16, 14, 13, 12, 11, 11, 10, 10] * 5
+                                24, 22, 20, 19, 17, 16, 14, 13, 12, 11, 11, 10, 10] * 2
 
         self.assertEqual(batch_sizes, expected_batch_sizes)
 

--- a/tests/test_CosineAnnealingBS.py
+++ b/tests/test_CosineAnnealingBS.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import CosineAnnealingBS
+from bs_scheduler import CosineAnnealingBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest
+    get_batch_sizes_across_epochs, BSTest, batched_dataset
 
 
 class TestCosineAnnealingBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'total_iters': 5,
+            'max_batch_size': 100,
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, CosineAnnealingBS, batch_size_manager, **kwargs)
 
     def test_dataloader_lengths(self):
         base_batch_size = 10

--- a/tests/test_CosineAnnealingBSWithWarmRestarts.py
+++ b/tests/test_CosineAnnealingBSWithWarmRestarts.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import CosineAnnealingBSWithWarmRestarts
+from bs_scheduler import CosineAnnealingBSWithWarmRestarts, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest
+    get_batch_sizes_across_epochs, BSTest, batched_dataset
 
 
 class TestCosineAnnealingBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            't_0': 5,
+            'max_batch_size': 100,
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, CosineAnnealingBSWithWarmRestarts, batch_size_manager, **kwargs)
 
     def test_dataloader_lengths(self):
         base_batch_size = 10

--- a/tests/test_CyclicBS.py
+++ b/tests/test_CyclicBS.py
@@ -201,11 +201,11 @@ class TestConstantBS(BSTest):
         base_batch_size = 100
         dataloader = create_dataloader(self.dataset, batch_size=base_batch_size)
         max_batch_size = 200
-        step_size_down = 50
+        step_size_down = 25
         gamma = 0.9
         scheduler = CyclicBS(dataloader, base_batch_size=base_batch_size, max_batch_size=max_batch_size,
                              step_size_down=step_size_down, mode='exp_range', gamma=gamma)
-        n_epochs = 10 * step_size_down
+        n_epochs = 6 * step_size_down
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         plt.plot(batch_sizes)

--- a/tests/test_CyclicBS.py
+++ b/tests/test_CyclicBS.py
@@ -2,14 +2,25 @@ import os
 import random
 import unittest
 
-from bs_scheduler import CyclicBS
-from tests.test_utils import create_dataloader, fashion_mnist, get_batch_sizes_across_epochs, BSTest, rint
+from bs_scheduler import CyclicBS, CustomBatchSizeManager
+from tests.test_utils import create_dataloader, fashion_mnist, get_batch_sizes_across_epochs, BSTest, rint, \
+    batched_dataset
 
 
 class TestConstantBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'base_batch_size': 100,
+            'step_size_down': 10,
+            'mode': 'triangular',
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, CyclicBS, batch_size_manager, **kwargs)
 
     def test_dataloader_batch_size_triangular(self):
         base_batch_size = 100

--- a/tests/test_ExponentialBS.py
+++ b/tests/test_ExponentialBS.py
@@ -1,15 +1,23 @@
 import os
 import unittest
 
-from bs_scheduler import ExponentialBS
+from bs_scheduler import ExponentialBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest
+    get_batch_sizes_across_epochs, BSTest, batched_dataset
 
 
 class TestExponentialBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'gamma': 1.01,
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, ExponentialBS, batch_size_manager, **kwargs)
 
     def test_dataloader_lengths(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)

--- a/tests/test_IncreaseBSOnPlateau.py
+++ b/tests/test_IncreaseBSOnPlateau.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import IncreaseBSOnPlateau
+from bs_scheduler import IncreaseBSOnPlateau, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    BSTest, get_batch_sizes_across_epochs
+    BSTest, get_batch_sizes_across_epochs, batched_dataset
 
 
 class TestIncreaseBSOnPlateau(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'mode': 'min',
+            'threshold_mode': 'rel',
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, IncreaseBSOnPlateau, batch_size_manager, **kwargs)
 
     def test_constant_metric(self):
         base_batch_size = 10

--- a/tests/test_LambdaBS.py
+++ b/tests/test_LambdaBS.py
@@ -22,7 +22,7 @@ class TestLambdaBS(BSTest):
                                          "always be equal to the inferred length except for Iterable Datasets for "
                                          "which the __len__ could be inaccurate.")
 
-        dataloader.batch_sampler.batch_size = 526
+        dataloader.batch_sampler.batch_size = 256
         real, inferred = iterate(dataloader)
         self.assertEqual(real, inferred, "Dataloader __len__ does not return the real length. The real length should "
                                          "always be equal to the inferred length except for Iterable Datasets for "
@@ -46,7 +46,7 @@ class TestLambdaBS(BSTest):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         fn = lambda epoch: 10 * epoch  # noqa: E731
         scheduler = LambdaBS(dataloader, fn)
-        n_epochs = 15
+        n_epochs = 10
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,

--- a/tests/test_LinearBS.py
+++ b/tests/test_LinearBS.py
@@ -3,15 +3,25 @@ import unittest
 
 import torch
 
-from bs_scheduler import LinearBS
+from bs_scheduler import LinearBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip, rint
+    get_batch_sizes_across_epochs, BSTest, clip, rint, batched_dataset
 
 
 class TestLinearBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'start_factor': 10.0,
+            'end_factor': 5.0,
+            'milestone': 5
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, LinearBS, batch_size_manager, **kwargs)
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, start_factor, end_factor, milestone, min_batch_size,

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import MultiStepBS
+from bs_scheduler import MultiStepBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, clip, rint
+    get_batch_sizes_across_epochs, BSTest, clip, rint, batched_dataset
 
 
 class TestMultiStepBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'gamma': 1.1,
+            'milestones': [70, 70, 80, 10, 50]
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, MultiStepBS, batch_size_manager, **kwargs)
 
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, milestones, gamma, min_batch_size, max_batch_size):

--- a/tests/test_MultiStepBS.py
+++ b/tests/test_MultiStepBS.py
@@ -47,10 +47,10 @@ class TestMultiStepBS(BSTest):
 
     def test_dataloader_batch_size(self):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        milestones = [5, 10, 10, 12]
+        milestones = [5, 7, 7, 9]
         gamma = 3.0
         scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
-        n_epochs = 15
+        n_epochs = 10
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, milestones, gamma,
@@ -60,7 +60,7 @@ class TestMultiStepBS(BSTest):
 
     def test_loading_and_unloading(self):
         dataloader = create_dataloader(self.dataset)
-        milestones = [5, 10, 10, 12]
+        milestones = [5, 7, 7, 9]
         gamma = 3.0
         scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
 
@@ -76,10 +76,10 @@ class TestMultiStepBS(BSTest):
         warnings.filterwarnings("ignore", category=UserWarning)
 
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
-        milestones = [5, 10, 10, 12]
+        milestones = [5, 7, 7, 9]
         gamma = 3.0
         scheduler = MultiStepBS(dataloader, milestones=milestones, gamma=gamma, max_batch_size=5000, verbose=False)
-        n_epochs = 15
+        n_epochs = 10
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         plt.plot(batch_sizes)

--- a/tests/test_MultiplicativeBS.py
+++ b/tests/test_MultiplicativeBS.py
@@ -37,7 +37,7 @@ class TestMultiplicativeBS(BSTest):
         dataloader = create_dataloader(self.dataset, batch_size=self.base_batch_size)
         fn = lambda epoch: epoch / 100 + 2  # noqa: E731
         scheduler = MultiplicativeBS(dataloader, fn, max_batch_size=5000, verbose=False)
-        n_epochs = 15
+        n_epochs = 10
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         expected_batch_sizes = self.compute_expected_batch_sizes(n_epochs, self.base_batch_size, fn,

--- a/tests/test_OneCycleBS.py
+++ b/tests/test_OneCycleBS.py
@@ -1,15 +1,27 @@
 import os
 import unittest
 
-from bs_scheduler import OneCycleBS
+from bs_scheduler import OneCycleBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest, rint
+    get_batch_sizes_across_epochs, BSTest, rint, batched_dataset
 
 
 class TestOneCycleBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'max_batch_size': 100,
+            'min_batch_size': 10,
+            'total_steps': 100,
+            'decay_percentage': 0.3,
+            'strategy': 'linear',
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, OneCycleBS, batch_size_manager, **kwargs)
 
     def test_dataloader_batch_size_linear(self):
         base_batch_size = 40

--- a/tests/test_PolynomialBS.py
+++ b/tests/test_PolynomialBS.py
@@ -1,15 +1,24 @@
 import os
 import unittest
 
-from bs_scheduler import PolynomialBS
+from bs_scheduler import PolynomialBS, CustomBatchSizeManager
 from tests.test_utils import create_dataloader, simulate_n_epochs, fashion_mnist, \
-    get_batch_sizes_across_epochs, BSTest
+    get_batch_sizes_across_epochs, BSTest, batched_dataset
 
 
 class TestPolynomialBS(BSTest):
     def setUp(self):
         self.base_batch_size = 64
         self.dataset = fashion_mnist()
+
+    def test_create(self):
+        dataloader = create_dataloader(batched_dataset(batch_size=self.base_batch_size), batch_size=None)
+        kwargs = {
+            'total_iters': 5,
+            'power': 1.0,
+        }
+        batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
+        self.create_scheduler(dataloader, PolynomialBS, batch_size_manager, **kwargs)
 
     def test_dataloader_lengths(self):
         base_batch_size = 10

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -107,7 +107,7 @@ class TestStepBS(BSTest):
         step_size = 50
         gamma = 1.1
         scheduler = StepBS(dataloader, step_size=step_size, gamma=gamma)
-        n_epochs = 300
+        n_epochs = 200
 
         batch_sizes = get_batch_sizes_across_epochs(dataloader, scheduler, n_epochs)
         plt.plot(batch_sizes)


### PR DESCRIPTION
* This makes the library compatible with non-PyTorch pipelines.
* Updated the tests.