### PR TITLE
Making torch.load used in tests compatible with torch2.6.0+

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bs-scheduler"
-version = "1.0.0"
+version = "1.0.1"
 requires-python = ">=3.9"
 description = "A PyTorch Dataloader compatible batch size scheduler library."
 readme = "README.md"

--- a/tests/test_StepBS.py
+++ b/tests/test_StepBS.py
@@ -20,7 +20,6 @@ class TestStepBS(BSTest):
         batch_size_manager = CustomBatchSizeManager(dataloader.dataset)
         self.create_scheduler(dataloader, StepBS, batch_size_manager, **kwargs)
 
-
     @staticmethod
     def compute_expected_batch_sizes(epochs, base_batch_size, step_size, gamma, min_batch_size, max_batch_size):
         expected_batch_sizes = [base_batch_size]  # Base batch size is added as a boundary condition.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -128,7 +128,7 @@ class BSTest(unittest.TestCase):
         tmp = tempfile.NamedTemporaryFile(delete=False)
         try:
             torch.save(state_dict, tmp.name)
-            state_dict = torch.load(tmp.name)
+            state_dict = torch.load(tmp.name, weights_only=False)
         finally:
             tmp.close()
             os.unlink(tmp.name)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,6 @@ import math
 import os
 import tempfile
 import unittest
-from sched import scheduler
 
 import torch
 from torch import Tensor


### PR DESCRIPTION
* torch.load must use `weights_only=False` to load scheduler state.